### PR TITLE
Use cursor pagination when listing incidents and sources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/Gaardsholt/go-gitguardian
 
 go 1.17
+
+require github.com/peterhellberg/link v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/peterhellberg/link v1.1.0 h1:s2+RH8EGuI/mI4QwrWGSYQCRz7uNgip9BaM04HKu5kc=
+github.com/peterhellberg/link v1.1.0/go.mod h1:gtSlOT4jmkY8P47hbTc8PTgiDDWpdPbFYl75keYyBB8=

--- a/incidents/Types.go
+++ b/incidents/Types.go
@@ -4,6 +4,11 @@ type Error struct {
 	Detail string `json:"detail"`
 }
 
+type PaginationMeta struct {
+	NextCursor     string
+	PreviousCursor string
+}
+
 type IncidentListResult struct {
 	Result []IncidentListResponse `json:"result"`
 	Error  *Error                 `json:"error"`

--- a/incidents/Types.go
+++ b/incidents/Types.go
@@ -4,11 +4,6 @@ type Error struct {
 	Detail string `json:"detail"`
 }
 
-type PaginationMeta struct {
-	NextCursor     string
-	PreviousCursor string
-}
-
 type IncidentListResult struct {
 	Result []IncidentListResponse `json:"result"`
 	Error  *Error                 `json:"error"`


### PR DESCRIPTION
Pagination with the page parameter is deprecated. I added support for cursor pagination when listing incidents, and added a new return value to be able to get to go to the previous or next page.

This should be done on other list API, I'll take a look after.