### PR TITLE
Fix date formating for date_before and date_after parameters

### DIFF
--- a/incidents/List.go
+++ b/incidents/List.go
@@ -72,11 +72,11 @@ func (c *IncidentsClient) List(lo ListOptions) (*IncidentListResult, error) {
 	}
 
 	if lo.DateBefore != nil {
-		q.Add("date_before", lo.DateBefore.Format("2019-08-30T14:15:22Z"))
+		q.Add("date_before", lo.DateBefore.Format(time.RFC3339Nano))
 	}
 
 	if lo.DateAfter != nil {
-		q.Add("date_after", lo.DateAfter.Format("2019-08-30T14:15:22Z"))
+		q.Add("date_after", lo.DateAfter.Format(time.RFC3339Nano))
 	}
 
 	if lo.Status != nil {


### PR DESCRIPTION
The formatting string is not correct. You see the result here: https://go.dev/play/p/55N2IQZ-G6Q