### PR TITLE
Moved json encoding to the `client` so we only have to handle it there

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -82,7 +82,13 @@ func New(opts ...ClientOption) (*Client, error) {
 	return &client, nil
 }
 
-func (c *Client) NewRequest(method string, path string, payload *bytes.Buffer) (*http.Request, error) {
+func (c *Client) NewRequest(method string, path string, body interface{}) (*http.Request, error) {
+	payload := new(bytes.Buffer)
+	err := json.NewEncoder(payload).Encode(body)
+	if err != nil {
+		return nil, err
+	}
+
 	// Convert server address to *url.URL
 	serverURL, err := url.Parse(c.Server)
 	if err != nil {

--- a/incidents/AssignSecretIncident.go
+++ b/incidents/AssignSecretIncident.go
@@ -1,7 +1,6 @@
 package incidents
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -35,13 +34,7 @@ type AssignSecretIncidentResult struct {
 }
 
 func (c *IncidentsClient) AssignSecretIncident(IncidentId int, lo AssignSecretIncidentOptions) (*AssignSecretIncidentResult, error) {
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(lo)
-	if err != nil {
-		return nil, err
-	}
-
-	r, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/assign", IncidentId), b)
+	r, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/assign", IncidentId), lo)
 	if err != nil {
 		return nil, err
 	}

--- a/incidents/CreateNote.go
+++ b/incidents/CreateNote.go
@@ -1,7 +1,6 @@
 package incidents
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -29,13 +28,7 @@ type IncidentCreateNoteResponse struct {
 }
 
 func (c *IncidentsClient) CreateNote(IncidentId int, lo CreateNoteOptions) (*IncidentCreateNoteResult, error) {
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(lo)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/notes", IncidentId), b)
+	req, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/notes", IncidentId), lo)
 	if err != nil {
 		return nil, err
 	}

--- a/incidents/GrantAccesSecretIncident.go
+++ b/incidents/GrantAccesSecretIncident.go
@@ -1,8 +1,6 @@
 package incidents
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -27,13 +25,7 @@ type GrantAccessSecretIncidentResult struct {
 }
 
 func (c *IncidentsClient) GrantAccessSecretIncident(IncidentId int, lo GrantAccessSecretIncidentOptions) (bool, error) {
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(lo)
-	if err != nil {
-		return false, err
-	}
-
-	r, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/grant_access", IncidentId), b)
+	r, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/grant_access", IncidentId), lo)
 	if err != nil {
 		return false, err
 	}

--- a/incidents/Ignore.go
+++ b/incidents/Ignore.go
@@ -1,7 +1,6 @@
 package incidents
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -71,14 +70,7 @@ type IncidentIgnoreError struct {
 }
 
 func (c *IncidentsClient) Ignore(IncidentId int, lo IgnoreOptions) (*IncidentIgnoreResult, error) {
-	b, err := json.Marshal(lo)
-	if err != nil {
-		return nil, err
-	}
-
-	bbuffer := bytes.NewBuffer(b)
-
-	req, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/ignore", IncidentId), bbuffer)
+	req, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/ignore", IncidentId), lo)
 	if err != nil {
 		return nil, err
 	}

--- a/incidents/ResolveSecretIncident.go
+++ b/incidents/ResolveSecretIncident.go
@@ -1,7 +1,6 @@
 package incidents
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -35,13 +34,7 @@ type ResolveSecretIncidentResult struct {
 }
 
 func (c *IncidentsClient) ResolveSecretIncident(IncidentId int, lo ResolveSecretIncidentOptions) (*ResolveSecretIncidentResult, error) {
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(lo)
-	if err != nil {
-		return nil, err
-	}
-
-	r, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/resolve", IncidentId), b)
+	r, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/resolve", IncidentId), lo)
 	if err != nil {
 		return nil, err
 	}

--- a/incidents/RevokeAccesSecretIncident.go
+++ b/incidents/RevokeAccesSecretIncident.go
@@ -1,8 +1,6 @@
 package incidents
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -27,13 +25,7 @@ type RevokeAccessSecretIncidentResult struct {
 }
 
 func (c *IncidentsClient) RevokeAccessSecretIncident(IncidentId int, lo RevokeAccessSecretIncidentOptions) (bool, error) {
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(lo)
-	if err != nil {
-		return false, err
-	}
-
-	r, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/revoke_access", IncidentId), b)
+	r, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/revoke_access", IncidentId), lo)
 	if err != nil {
 		return false, err
 	}

--- a/incidents/ShareSecretIncident.go
+++ b/incidents/ShareSecretIncident.go
@@ -1,7 +1,6 @@
 package incidents
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,13 +26,7 @@ type ShareSecretIncidentResult struct {
 }
 
 func (c *IncidentsClient) ShareSecretIncident(IncidentId int, lo ShareSecretIncidentOptions) (*ShareSecretIncidentResult, error) {
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(lo)
-	if err != nil {
-		return nil, err
-	}
-
-	r, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/share", IncidentId), b)
+	r, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/incidents/secrets/%d/share", IncidentId), lo)
 	if err != nil {
 		return nil, err
 	}

--- a/incidents/UpdateNote.go
+++ b/incidents/UpdateNote.go
@@ -1,7 +1,6 @@
 package incidents
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -29,13 +28,7 @@ type IncidentUpdateNoteResponse struct {
 }
 
 func (c *IncidentsClient) UpdateNote(IncidentId int, NoteId int, lo UpdateNoteOptions) (*IncidentUpdateNoteResult, error) {
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(lo)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := c.client.NewRequest("PATCH", fmt.Sprintf("/v1/incidents/secrets/%d/notes/%d", IncidentId, NoteId), b)
+	req, err := c.client.NewRequest("PATCH", fmt.Sprintf("/v1/incidents/secrets/%d/notes/%d", IncidentId, NoteId), lo)
 	if err != nil {
 		return nil, err
 	}

--- a/invitations/Create.go
+++ b/invitations/Create.go
@@ -1,7 +1,6 @@
 package invitations
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,13 +33,7 @@ const (
 )
 
 func (c *InvitationsClient) Create(lo InvitationsCreateOptions) (*InvitationsCreateResult, error) {
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(lo)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := c.client.NewRequest("POST", "/v1/invitations", b)
+	req, err := c.client.NewRequest("POST", "/v1/invitations", lo)
 	if err != nil {
 		return nil, err
 	}

--- a/scan/ContentScan.go
+++ b/scan/ContentScan.go
@@ -1,21 +1,13 @@
 package scan
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
 )
 
 func (c *ScanClient) ContentScan(payload ContentScanPayload) (*ContentScanResult, error) {
-
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(payload)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := c.client.NewRequest("POST", "/v1/scan", b)
+	req, err := c.client.NewRequest("POST", "/v1/scan", payload)
 	if err != nil {
 		return nil, err
 	}

--- a/scan/MultipleContentScan.go
+++ b/scan/MultipleContentScan.go
@@ -1,21 +1,13 @@
 package scan
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
 )
 
 func (c *ScanClient) MultipleContentScan(payload []ContentScanPayload) (*MultipleContentScanResult, error) {
-
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(payload)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := c.client.NewRequest("POST", "/v1/multiscan", b)
+	req, err := c.client.NewRequest("POST", "/v1/multiscan", payload)
 	if err != nil {
 		return nil, err
 	}

--- a/teams/AddMember.go
+++ b/teams/AddMember.go
@@ -15,13 +15,7 @@ type TeamsAddMemberOptions struct {
 }
 
 func (c *TeamsClient) AddMember(TeamId int, lo TeamsAddMemberOptions) (*ListMembershipsResult, error) {
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(lo)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/teams/%d/team_memberships", TeamId), b)
+	req, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/teams/%d/team_memberships", TeamId), lo)
 	if err != nil {
 		return nil, err
 	}

--- a/teams/Create.go
+++ b/teams/Create.go
@@ -1,7 +1,6 @@
 package teams
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -17,13 +16,7 @@ type TeamsCreateOptions struct {
 }
 
 func (c *TeamsClient) Create(lo TeamsCreateOptions) (*TeamsCreateResult, error) {
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(lo)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := c.client.NewRequest("POST", "/v1/teams", b)
+	req, err := c.client.NewRequest("POST", "/v1/teams", lo)
 	if err != nil {
 		return nil, err
 	}

--- a/teams/Update.go
+++ b/teams/Update.go
@@ -1,7 +1,6 @@
 package teams
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,13 +12,7 @@ type Update struct {
 }
 
 func (c *TeamsClient) Update(TeamId int, lo Update) (*TeamGetResult, error) {
-	payload := new(bytes.Buffer)
-	err := json.NewEncoder(payload).Encode(lo)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := c.client.NewRequest("PATCH", fmt.Sprintf("/v1/teams/%d", TeamId), payload)
+	req, err := c.client.NewRequest("PATCH", fmt.Sprintf("/v1/teams/%d", TeamId), lo)
 	if err != nil {
 		return nil, err
 	}

--- a/teams/UpdatePerimeter.go
+++ b/teams/UpdatePerimeter.go
@@ -1,7 +1,6 @@
 package teams
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -22,13 +21,7 @@ func (c *TeamsClient) UpdatePerimeter(TeamId int, lo UpdatePerimeterOptions) err
 		lo.SourcesToRemove = []int64{}
 	}
 
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(lo)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/teams/%d/sources", TeamId), b)
+	req, err := c.client.NewRequest("POST", fmt.Sprintf("/v1/teams/%d/sources", TeamId), lo)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Moved the json encoding of the body, from each of the methods into the client  - Yaay less duplicate code